### PR TITLE
Broadcasts: новий модуль розсилок у Filament

### DIFF
--- a/app/Filament/Pages/ManageTelegram.php
+++ b/app/Filament/Pages/ManageTelegram.php
@@ -39,6 +39,9 @@ class ManageTelegram extends SettingsPage
                         Toggle::make('show_stock_group')
                             ->label('Склад (Бренди, Товари, Підкатегорії, Поставки, Залишки)')
                             ->default(true),
+                        Toggle::make('show_broadcasts_group')
+                            ->label('Розсилка (Розсилки, Підписники)')
+                            ->default(true),
                     ])
                     ->columns(1)
                     ->collapsible(),

--- a/app/Filament/Resources/BroadcastResource.php
+++ b/app/Filament/Resources/BroadcastResource.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\BroadcastResource\Pages;
+use App\Models\Broadcast;
+use App\Models\Member;
+use App\Services\BroadcastService;
+use App\Settings\TelegramSettings;
+use Filament\Forms;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\HtmlString;
+
+class BroadcastResource extends Resource
+{
+    protected static ?string $model = Broadcast::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-megaphone';
+    protected static ?string $navigationLabel = 'Розсилка';
+    protected static ?string $label = 'Розсилку';
+    protected static ?string $pluralLabel = 'Розсилки';
+    protected static ?string $navigationGroup = 'Розсилка';
+    protected static ?int $navigationSort = 0;
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        try {
+            return (bool) app(TelegramSettings::class)->show_broadcasts_group;
+        } catch (\Throwable $e) {
+            return true;
+        }
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Select::make('audience')
+                    ->label('Кому відправляти')
+                    ->options(Broadcast::AUDIENCES)
+                    ->default(Broadcast::AUDIENCE_ALL)
+                    ->required()
+                    ->reactive()
+                    ->live(),
+
+                RichEditor::make('message')
+                    ->label('Текст повідомлення')
+                    ->required()
+                    ->toolbarButtons([
+                        'bold',
+                        'italic',
+                        'underline',
+                        'strike',
+                        'link',
+                        'blockquote',
+                        'codeBlock',
+                        'bulletList',
+                        'orderedList',
+                        'undo',
+                        'redo',
+                    ])
+                    ->helperText('Виділіть текст і натисніть кнопку на панелі (Жирний, Курсив тощо), як у Word. Форматування автоматично відобразиться у повідомленні Telegram.')
+                    ->columnSpanFull(),
+
+                FileUpload::make('image_path')
+                    ->label('Зображення (опціонально)')
+                    ->image()
+                    ->imageEditor()
+                    ->directory('broadcasts')
+                    ->disk('public')
+                    ->maxSize(5120)
+                    ->helperText('Якщо завантажене — буде надіслано фото з підписом. При тексті понад 1024 символи фото надсилається окремо.'),
+
+                Select::make('excluded_member_ids')
+                    ->label('Виключити з цієї розсилки')
+                    ->helperText('Виберіть користувачів, яким НЕ потрібно надсилати саме цю розсилку. Це разове виключення, на майбутні розсилки воно не впливає.')
+                    ->multiple()
+                    ->searchable()
+                    ->preload(false)
+                    ->live()
+                    ->getSearchResultsUsing(function (string $search, Get $get): array {
+                        $audience = $get('audience') ?? Broadcast::AUDIENCE_ALL;
+
+                        return app(BroadcastService::class)
+                            ->audienceQuery($audience)
+                            ->where(function ($q) use ($search) {
+                                $like = '%' . $search . '%';
+                                $q->where('full_name', 'like', $like)
+                                  ->orWhere('username', 'like', $like)
+                                  ->orWhere('phone', 'like', $like)
+                                  ->orWhere('telegram_id', 'like', $like);
+                            })
+                            ->orderBy('full_name')
+                            ->limit(50)
+                            ->get(['id', 'full_name', 'username', 'telegram_id'])
+                            ->mapWithKeys(fn (Member $m) => [
+                                $m->id => static::memberOptionLabel($m),
+                            ])
+                            ->toArray();
+                    })
+                    ->getOptionLabelsUsing(function (array $values): array {
+                        return Member::query()
+                            ->whereIn('id', $values)
+                            ->get(['id', 'full_name', 'username', 'telegram_id'])
+                            ->mapWithKeys(fn (Member $m) => [
+                                $m->id => static::memberOptionLabel($m),
+                            ])
+                            ->toArray();
+                    }),
+
+                Placeholder::make('recipients_preview')
+                    ->label('Кількість одержувачів')
+                    ->content(function (Get $get): HtmlString {
+                        $audience = $get('audience') ?? Broadcast::AUDIENCE_ALL;
+                        $service = app(BroadcastService::class);
+
+                        $total = $service->audienceQuery($audience)->count();
+                        $excluded = (array) ($get('excluded_member_ids') ?? []);
+                        $excludedCount = !empty($excluded)
+                            ? $service->audienceQuery($audience)
+                                ->whereIn('id', $excluded)
+                                ->count()
+                            : 0;
+
+                        $willSend = max(0, $total - $excludedCount);
+
+                        return new HtmlString(
+                            'Буде відправлено: <span style="font-weight:600">' . $willSend . '</span> з '
+                            . $total . ' користувачів (виключено: ' . $excludedCount . ').'
+                        );
+                    }),
+
+                Placeholder::make('schedule_hint')
+                    ->label('Інтервал відправки')
+                    ->content('Повідомлення будуть надсилатись по черзі з випадковим інтервалом 30-60 секунд між одержувачами.'),
+            ]);
+    }
+
+    protected static function memberOptionLabel(Member $member): string
+    {
+        $name = $member->full_name ?: 'Без імені';
+        $extras = [];
+
+        if ($member->username) {
+            $extras[] = '@' . $member->username;
+        }
+        if ($member->telegram_id) {
+            $extras[] = 'id ' . $member->telegram_id;
+        }
+
+        return $extras
+            ? $name . ' (' . implode(', ', $extras) . ')'
+            : $name;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->orderByDesc('created_at'))
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('#')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('message')
+                    ->label('Повідомлення')
+                    ->limit(60)
+                    ->wrap(),
+
+                Tables\Columns\TextColumn::make('audience')
+                    ->label('Аудиторія')
+                    ->formatStateUsing(fn ($state) => Broadcast::AUDIENCES[$state] ?? $state)
+                    ->badge()
+                    ->color('info'),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Статус')
+                    ->formatStateUsing(fn ($state) => Broadcast::STATUSES[$state] ?? $state)
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        Broadcast::STATUS_PENDING => 'gray',
+                        Broadcast::STATUS_IN_PROGRESS => 'warning',
+                        Broadcast::STATUS_COMPLETED => 'success',
+                        Broadcast::STATUS_CANCELLED => 'danger',
+                        default => 'gray',
+                    }),
+
+                Tables\Columns\TextColumn::make('progress')
+                    ->label('Прогрес')
+                    ->state(function (Broadcast $record): string {
+                        $processed = $record->sent_count + $record->failed_count;
+                        return $processed . ' / ' . $record->total_recipients
+                            . ' (' . $record->progress_percent . '%)';
+                    }),
+
+                Tables\Columns\TextColumn::make('sent_count')
+                    ->label('Успішно')
+                    ->color('success'),
+
+                Tables\Columns\TextColumn::make('failed_count')
+                    ->label('Помилки')
+                    ->color('danger'),
+
+                Tables\Columns\TextColumn::make('author.name')
+                    ->label('Автор')
+                    ->toggleable(),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Створено')
+                    ->dateTime('d.m.Y H:i')
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->label('Статус')
+                    ->options(Broadcast::STATUSES),
+                Tables\Filters\SelectFilter::make('audience')
+                    ->label('Аудиторія')
+                    ->options(Broadcast::AUDIENCES),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make()->label('Деталі'),
+                Tables\Actions\Action::make('cancel')
+                    ->label('Скасувати')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (Broadcast $record) => !$record->isFinished())
+                    ->action(function (Broadcast $record) {
+                        app(BroadcastService::class)->cancel($record);
+                    }),
+            ])
+            ->bulkActions([])
+            ->poll('10s');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            BroadcastResource\RelationManagers\RecipientsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBroadcasts::route('/'),
+            'create' => Pages\CreateBroadcast::route('/create'),
+            'view' => Pages\ViewBroadcast::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BroadcastResource/Pages/CreateBroadcast.php
+++ b/app/Filament/Resources/BroadcastResource/Pages/CreateBroadcast.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Resources\BroadcastResource\Pages;
+
+use App\Filament\Resources\BroadcastResource;
+use App\Models\Broadcast;
+use App\Services\BroadcastService;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Validation\ValidationException;
+
+class CreateBroadcast extends CreateRecord
+{
+    protected static string $resource = BroadcastResource::class;
+
+    public function getTitle(): string
+    {
+        return 'Нова розсилка';
+    }
+
+    protected function getCreateFormAction(): \Filament\Actions\Action
+    {
+        return parent::getCreateFormAction()->label('Запустити розсилку');
+    }
+
+    protected function getCreateAnotherFormAction(): \Filament\Actions\Action
+    {
+        return parent::getCreateAnotherFormAction()->label('Запустити та створити нову');
+    }
+
+    protected function handleRecordCreation(array $data): Broadcast
+    {
+        /** @var BroadcastService $service */
+        $service = app(BroadcastService::class);
+
+        $audience = $data['audience'] ?? Broadcast::AUDIENCE_ALL;
+        $excluded = $data['excluded_member_ids'] ?? [];
+        $recipientsCount = $service->audienceQuery($audience)
+            ->when(!empty($excluded), fn ($q) => $q->whereNotIn('id', $excluded))
+            ->count();
+
+        if ($recipientsCount === 0) {
+            Notification::make()
+                ->title('Немає одержувачів')
+                ->body('Після виключень не залишилось користувачів для відправки. Розсилка не створена.')
+                ->danger()
+                ->send();
+
+            throw ValidationException::withMessages([
+                'data.audience' => 'Після виключень не залишилось одержувачів.',
+            ]);
+        }
+
+        $broadcast = $service->create($data, auth()->id());
+        $service->dispatch($broadcast);
+
+        Notification::make()
+            ->title('Розсилка запущена')
+            ->body('Заплановано відправку для ' . $broadcast->total_recipients . ' одержувач(ів).')
+            ->success()
+            ->send();
+
+        return $broadcast;
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('view', ['record' => $this->record]);
+    }
+}

--- a/app/Filament/Resources/BroadcastResource/Pages/ListBroadcasts.php
+++ b/app/Filament/Resources/BroadcastResource/Pages/ListBroadcasts.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\BroadcastResource\Pages;
+
+use App\Filament\Resources\BroadcastResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBroadcasts extends ListRecords
+{
+    protected static string $resource = BroadcastResource::class;
+
+    public function getTitle(): string
+    {
+        return 'Розсилки';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->label('Нова розсилка')
+                ->icon('heroicon-o-paper-airplane'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BroadcastResource/Pages/ViewBroadcast.php
+++ b/app/Filament/Resources/BroadcastResource/Pages/ViewBroadcast.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Filament\Resources\BroadcastResource\Pages;
+
+use App\Filament\Resources\BroadcastResource;
+use App\Models\Broadcast;
+use App\Services\BroadcastService;
+use Filament\Actions;
+use Filament\Infolists\Components\ImageEntry;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Components\ViewEntry;
+use Filament\Infolists\Infolist;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewBroadcast extends ViewRecord
+{
+    protected static string $resource = BroadcastResource::class;
+
+    protected ?string $pollingInterval = '5s';
+
+    public function getTitle(): string
+    {
+        return 'Розсилка #' . $this->record->id;
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('cancel')
+                ->label('Скасувати розсилку')
+                ->color('danger')
+                ->icon('heroicon-o-x-circle')
+                ->requiresConfirmation()
+                ->visible(fn () => !$this->record->isFinished())
+                ->action(function () {
+                    app(BroadcastService::class)->cancel($this->record);
+
+                    Notification::make()
+                        ->title('Розсилку скасовано')
+                        ->body('Залишок повідомлень не буде відправлено.')
+                        ->success()
+                        ->send();
+
+                    $this->refreshFormData([
+                        'status',
+                        'sent_count',
+                        'failed_count',
+                        'finished_at',
+                    ]);
+                }),
+        ];
+    }
+
+    public function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Інформація про розсилку')
+                    ->schema([
+                        TextEntry::make('status')
+                            ->label('Статус')
+                            ->formatStateUsing(fn ($state) => Broadcast::STATUSES[$state] ?? $state)
+                            ->badge()
+                            ->color(fn (string $state): string => match ($state) {
+                                Broadcast::STATUS_PENDING => 'gray',
+                                Broadcast::STATUS_IN_PROGRESS => 'warning',
+                                Broadcast::STATUS_COMPLETED => 'success',
+                                Broadcast::STATUS_CANCELLED => 'danger',
+                                default => 'gray',
+                            }),
+
+                        TextEntry::make('audience')
+                            ->label('Аудиторія')
+                            ->formatStateUsing(fn ($state) => Broadcast::AUDIENCES[$state] ?? $state)
+                            ->badge()
+                            ->color('info'),
+
+                        TextEntry::make('author.name')
+                            ->label('Автор')
+                            ->placeholder('—'),
+
+                        TextEntry::make('created_at')
+                            ->label('Створено')
+                            ->dateTime('d.m.Y H:i'),
+
+                        TextEntry::make('started_at')
+                            ->label('Старт відправки')
+                            ->dateTime('d.m.Y H:i')
+                            ->placeholder('—'),
+
+                        TextEntry::make('finished_at')
+                            ->label('Завершено')
+                            ->dateTime('d.m.Y H:i')
+                            ->placeholder('—'),
+                    ])
+                    ->columns(3),
+
+                Section::make('Прогрес')
+                    ->schema([
+                        ViewEntry::make('progress')
+                            ->view('filament.broadcasts.progress'),
+
+                        TextEntry::make('total_recipients')
+                            ->label('Всього одержувачів'),
+                        TextEntry::make('sent_count')
+                            ->label('Успішно відправлено')
+                            ->color('success'),
+                        TextEntry::make('failed_count')
+                            ->label('Помилки')
+                            ->color('danger'),
+                    ])
+                    ->columns(3),
+
+                Section::make('Текст повідомлення')
+                    ->schema([
+                        TextEntry::make('message')
+                            ->label('')
+                            ->html()
+                            ->columnSpanFull(),
+                        ImageEntry::make('image_path')
+                            ->label('Зображення')
+                            ->disk('public')
+                            ->visible(fn (Broadcast $record): bool => !empty($record->image_path))
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/BroadcastResource/RelationManagers/RecipientsRelationManager.php
+++ b/app/Filament/Resources/BroadcastResource/RelationManagers/RecipientsRelationManager.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources\BroadcastResource\RelationManagers;
+
+use App\Models\BroadcastRecipient;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class RecipientsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'recipients';
+    protected static ?string $title = 'Одержувачі';
+    protected static ?string $recordTitleAttribute = 'id';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('member.full_name')
+                    ->label('Імʼя')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('member.username')
+                    ->label('Username')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('telegram_id')
+                    ->label('Telegram ID')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Статус')
+                    ->formatStateUsing(fn ($state) => BroadcastRecipient::STATUSES[$state] ?? $state)
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        BroadcastRecipient::STATUS_SENT => 'success',
+                        BroadcastRecipient::STATUS_FAILED => 'danger',
+                        BroadcastRecipient::STATUS_SKIPPED => 'gray',
+                        default => 'warning',
+                    }),
+                Tables\Columns\TextColumn::make('sent_at')
+                    ->label('Час відправки')
+                    ->dateTime('d.m.Y H:i:s')
+                    ->placeholder('—'),
+                Tables\Columns\TextColumn::make('error_message')
+                    ->label('Помилка')
+                    ->limit(60)
+                    ->wrap()
+                    ->placeholder('—')
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->label('Статус')
+                    ->options(BroadcastRecipient::STATUSES),
+            ])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([])
+            ->defaultSort('id', 'asc')
+            ->poll('5s');
+    }
+}

--- a/app/Jobs/SendBroadcastMessageJob.php
+++ b/app/Jobs/SendBroadcastMessageJob.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Broadcast;
+use App\Models\BroadcastRecipient;
+use App\Services\TelegramHtmlConverter;
+use App\Services\TelegramService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class SendBroadcastMessageJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public int $recipientId)
+    {
+    }
+
+    public function handle(TelegramService $telegram): void
+    {
+        /** @var BroadcastRecipient|null $recipient */
+        $recipient = BroadcastRecipient::with('broadcast')->find($this->recipientId);
+
+        if (!$recipient) {
+            return;
+        }
+
+        $broadcast = $recipient->broadcast;
+
+        if (!$broadcast || $broadcast->status === Broadcast::STATUS_CANCELLED) {
+            if ($recipient->status === BroadcastRecipient::STATUS_PENDING) {
+                $recipient->update([
+                    'status' => BroadcastRecipient::STATUS_SKIPPED,
+                    'error_message' => 'Розсилку скасовано',
+                ]);
+                $broadcast?->refreshCounters();
+            }
+            return;
+        }
+
+        if ($recipient->status !== BroadcastRecipient::STATUS_PENDING) {
+            return;
+        }
+
+        if ($broadcast->status === Broadcast::STATUS_PENDING) {
+            $broadcast->update([
+                'status' => Broadcast::STATUS_IN_PROGRESS,
+                'started_at' => $broadcast->started_at ?? now(),
+            ]);
+        }
+
+        if (empty($recipient->telegram_id)) {
+            $recipient->update([
+                'status' => BroadcastRecipient::STATUS_SKIPPED,
+                'error_message' => 'Відсутній telegram_id',
+            ]);
+            $broadcast->refreshCounters();
+            return;
+        }
+
+        try {
+            $parseMode = $broadcast->getEffectiveParseMode();
+            $rawMessage = (string) $broadcast->message;
+            $message = $parseMode === Broadcast::PARSE_MODE_HTML
+                ? app(TelegramHtmlConverter::class)->convert($rawMessage)
+                : $rawMessage;
+
+            $hasImage = !empty($broadcast->image_path)
+                && Storage::disk('public')->exists($broadcast->image_path);
+
+            if ($hasImage) {
+                $absolutePath = Storage::disk('public')->path($broadcast->image_path);
+                $messageLength = mb_strlen($message);
+
+                if ($messageLength <= 1024) {
+                    $telegram->sendPhoto(
+                        $recipient->telegram_id,
+                        $absolutePath,
+                        $message !== '' ? $message : null,
+                        $parseMode
+                    );
+                } else {
+                    $telegram->sendPhoto($recipient->telegram_id, $absolutePath);
+                    $telegram->sendMessage($recipient->telegram_id, $message, $parseMode);
+                }
+            } else {
+                $telegram->sendMessage($recipient->telegram_id, $message, $parseMode);
+            }
+
+            $recipient->update([
+                'status' => BroadcastRecipient::STATUS_SENT,
+                'sent_at' => now(),
+                'error_message' => null,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('[Broadcast] failed to send message', [
+                'broadcast_id' => $broadcast->id,
+                'recipient_id' => $recipient->id,
+                'telegram_id' => $recipient->telegram_id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $recipient->update([
+                'status' => BroadcastRecipient::STATUS_FAILED,
+                'error_message' => mb_substr($e->getMessage(), 0, 500),
+            ]);
+        }
+
+        $broadcast->refreshCounters();
+    }
+}

--- a/app/Models/Broadcast.php
+++ b/app/Models/Broadcast.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Broadcast extends Model
+{
+    use HasFactory;
+
+    public const AUDIENCE_ALL = 'all';
+    public const AUDIENCE_SUBSCRIBED = 'subscribed';
+    public const AUDIENCE_UNSUBSCRIBED = 'unsubscribed';
+
+    public const AUDIENCES = [
+        self::AUDIENCE_ALL => 'Всі користувачі',
+        self::AUDIENCE_SUBSCRIBED => 'З підпискою на канал',
+        self::AUDIENCE_UNSUBSCRIBED => 'Без підписки на канал',
+    ];
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_IN_PROGRESS = 'in_progress';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    public const STATUSES = [
+        self::STATUS_PENDING => 'В очікуванні',
+        self::STATUS_IN_PROGRESS => 'Відправляється',
+        self::STATUS_COMPLETED => 'Завершено',
+        self::STATUS_CANCELLED => 'Скасовано',
+    ];
+
+    public const PARSE_MODE_NONE = 'none';
+    public const PARSE_MODE_HTML = 'HTML';
+    public const PARSE_MODE_MARKDOWN = 'Markdown';
+
+    public const PARSE_MODES = [
+        self::PARSE_MODE_NONE => 'Без форматування',
+        self::PARSE_MODE_HTML => 'HTML',
+        self::PARSE_MODE_MARKDOWN => 'Markdown',
+    ];
+
+    protected $fillable = [
+        'message',
+        'image_path',
+        'parse_mode',
+        'audience',
+        'status',
+        'total_recipients',
+        'sent_count',
+        'failed_count',
+        'created_by_user_id',
+        'started_at',
+        'finished_at',
+    ];
+
+    protected $casts = [
+        'total_recipients' => 'integer',
+        'sent_count' => 'integer',
+        'failed_count' => 'integer',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+    ];
+
+    public function recipients(): HasMany
+    {
+        return $this->hasMany(BroadcastRecipient::class);
+    }
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    public function getProgressPercentAttribute(): int
+    {
+        if ($this->total_recipients <= 0) {
+            return 0;
+        }
+
+        $processed = $this->sent_count + $this->failed_count;
+
+        return (int) floor(($processed / $this->total_recipients) * 100);
+    }
+
+    public function getAudienceLabelAttribute(): string
+    {
+        return self::AUDIENCES[$this->audience] ?? $this->audience;
+    }
+
+    public function getStatusLabelAttribute(): string
+    {
+        return self::STATUSES[$this->status] ?? $this->status;
+    }
+
+    public function isFinished(): bool
+    {
+        return in_array($this->status, [self::STATUS_COMPLETED, self::STATUS_CANCELLED], true);
+    }
+
+    public function getImageUrlAttribute(): ?string
+    {
+        if (empty($this->image_path)) {
+            return null;
+        }
+
+        return asset('storage/' . $this->image_path);
+    }
+
+    public function getEffectiveParseMode(): ?string
+    {
+        if (!$this->parse_mode || $this->parse_mode === self::PARSE_MODE_NONE) {
+            return null;
+        }
+
+        return $this->parse_mode;
+    }
+
+    public function refreshCounters(): void
+    {
+        $this->sent_count = $this->recipients()->where('status', BroadcastRecipient::STATUS_SENT)->count();
+        $this->failed_count = $this->recipients()->where('status', BroadcastRecipient::STATUS_FAILED)->count();
+
+        $pending = $this->recipients()->where('status', BroadcastRecipient::STATUS_PENDING)->count();
+
+        if ($pending === 0 && $this->status !== self::STATUS_CANCELLED) {
+            $this->status = self::STATUS_COMPLETED;
+            $this->finished_at = $this->finished_at ?? now();
+        }
+
+        $this->save();
+    }
+}

--- a/app/Models/BroadcastRecipient.php
+++ b/app/Models/BroadcastRecipient.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BroadcastRecipient extends Model
+{
+    use HasFactory;
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_SENT = 'sent';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_SKIPPED = 'skipped';
+
+    public const STATUSES = [
+        self::STATUS_PENDING => 'В очікуванні',
+        self::STATUS_SENT => 'Відправлено',
+        self::STATUS_FAILED => 'Помилка',
+        self::STATUS_SKIPPED => 'Пропущено',
+    ];
+
+    protected $fillable = [
+        'broadcast_id',
+        'member_id',
+        'telegram_id',
+        'status',
+        'error_message',
+        'sent_at',
+    ];
+
+    protected $casts = [
+        'sent_at' => 'datetime',
+    ];
+
+    public function broadcast(): BelongsTo
+    {
+        return $this->belongsTo(Broadcast::class);
+    }
+
+    public function member(): BelongsTo
+    {
+        return $this->belongsTo(Member::class);
+    }
+
+    public function getStatusLabelAttribute(): string
+    {
+        return self::STATUSES[$this->status] ?? $this->status;
+    }
+}

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -27,6 +27,7 @@ class Member extends Model
     protected $casts = [
         'checkout_state' => 'array',
         'ui_state' => 'array',
+        'is_subscribed' => 'boolean',
     ];
 
     public function promocode()
@@ -47,6 +48,11 @@ class Member extends Model
     public function cartItems()
     {
         return $this->hasMany(CartItem::class);
+    }
+
+    public function broadcastRecipients()
+    {
+        return $this->hasMany(BroadcastRecipient::class);
     }
 
     public function getCartTotalAttribute()

--- a/app/Services/BroadcastService.php
+++ b/app/Services/BroadcastService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\SendBroadcastMessageJob;
+use App\Models\Broadcast;
+use App\Models\BroadcastRecipient;
+use App\Models\Member;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class BroadcastService
+{
+    public const MIN_INTERVAL_SECONDS = 30;
+    public const MAX_INTERVAL_SECONDS = 60;
+
+    public function create(array $data, ?int $userId = null): Broadcast
+    {
+        return DB::transaction(function () use ($data, $userId) {
+            $excludedIds = array_map('intval', $data['excluded_member_ids'] ?? []);
+
+            $broadcast = Broadcast::create([
+                'message' => $data['message'],
+                'image_path' => $data['image_path'] ?? null,
+                'parse_mode' => Broadcast::PARSE_MODE_HTML,
+                'audience' => $data['audience'] ?? Broadcast::AUDIENCE_ALL,
+                'status' => Broadcast::STATUS_PENDING,
+                'created_by_user_id' => $userId,
+            ]);
+
+            $members = $this->resolveAudience($broadcast->audience)
+                ->when(!empty($excludedIds), fn ($q) => $q->whereNotIn('id', $excludedIds))
+                ->get(['id', 'telegram_id']);
+
+            $now = now();
+            $rows = [];
+            foreach ($members as $member) {
+                $rows[] = [
+                    'broadcast_id' => $broadcast->id,
+                    'member_id' => $member->id,
+                    'telegram_id' => $member->telegram_id,
+                    'status' => BroadcastRecipient::STATUS_PENDING,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+
+            if (!empty($rows)) {
+                foreach (array_chunk($rows, 500) as $chunk) {
+                    BroadcastRecipient::insert($chunk);
+                }
+            }
+
+            $broadcast->total_recipients = count($rows);
+            $broadcast->save();
+
+            return $broadcast;
+        });
+    }
+
+    public function dispatch(Broadcast $broadcast): void
+    {
+        $recipients = $broadcast->recipients()
+            ->where('status', BroadcastRecipient::STATUS_PENDING)
+            ->orderBy('id')
+            ->get(['id']);
+
+        $delay = 0;
+        foreach ($recipients as $recipient) {
+            SendBroadcastMessageJob::dispatch($recipient->id)
+                ->delay(now()->addSeconds($delay));
+
+            $delay += random_int(self::MIN_INTERVAL_SECONDS, self::MAX_INTERVAL_SECONDS);
+        }
+
+        if ($broadcast->status === Broadcast::STATUS_PENDING && $recipients->isNotEmpty()) {
+            $broadcast->update(['status' => Broadcast::STATUS_IN_PROGRESS]);
+        }
+
+        if ($recipients->isEmpty() && $broadcast->total_recipients === 0) {
+            $broadcast->update([
+                'status' => Broadcast::STATUS_COMPLETED,
+                'finished_at' => now(),
+            ]);
+        }
+    }
+
+    public function cancel(Broadcast $broadcast): void
+    {
+        if ($broadcast->isFinished()) {
+            return;
+        }
+
+        DB::transaction(function () use ($broadcast) {
+            $broadcast->recipients()
+                ->where('status', BroadcastRecipient::STATUS_PENDING)
+                ->update([
+                    'status' => BroadcastRecipient::STATUS_SKIPPED,
+                    'error_message' => 'Розсилку скасовано',
+                    'updated_at' => now(),
+                ]);
+
+            $broadcast->update([
+                'status' => Broadcast::STATUS_CANCELLED,
+                'finished_at' => now(),
+            ]);
+
+            $broadcast->refreshCounters();
+        });
+    }
+
+    public function audienceQuery(string $audience): Builder
+    {
+        return $this->resolveAudience($audience);
+    }
+
+    protected function resolveAudience(string $audience): Builder
+    {
+        $query = Member::query()
+            ->whereNotNull('telegram_id')
+            ->where('telegram_id', '!=', '');
+
+        if ($audience === Broadcast::AUDIENCE_SUBSCRIBED) {
+            $query->where('is_subscribed', true);
+        } elseif ($audience === Broadcast::AUDIENCE_UNSUBSCRIBED) {
+            $query->where(function (Builder $q) {
+                $q->where('is_subscribed', false)->orWhereNull('is_subscribed');
+            });
+        }
+
+        return $query;
+    }
+}

--- a/app/Services/TelegramHtmlConverter.php
+++ b/app/Services/TelegramHtmlConverter.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Services;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+
+/**
+ * Конвертує HTML з Filament RichEditor (Trix) у HTML, що підтримується
+ * Telegram Bot API (parse_mode=HTML).
+ *
+ * Telegram дозволяє лише: <b>, <i>, <u>, <s>, <a>, <code>, <pre>, <blockquote>, <tg-spoiler>.
+ * Усе інше треба трансформувати у текст з \n або у вкладений дозволений тег.
+ */
+class TelegramHtmlConverter
+{
+    public function convert(?string $html): string
+    {
+        if ($html === null) {
+            return '';
+        }
+
+        $html = trim($html);
+        if ($html === '') {
+            return '';
+        }
+
+        libxml_use_internal_errors(true);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $wrapped = '<?xml encoding="UTF-8"?><div>' . $html . '</div>';
+        $dom->loadHTML($wrapped, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+        libxml_clear_errors();
+
+        $root = $dom->getElementsByTagName('div')->item(0);
+        $result = $root ? $this->renderChildren($root) : '';
+
+        $result = preg_replace("/\n{3,}/", "\n\n", $result);
+
+        return trim($result);
+    }
+
+    protected function renderChildren(DOMNode $node): string
+    {
+        $out = '';
+        foreach ($node->childNodes as $child) {
+            $out .= $this->renderNode($child);
+        }
+
+        return $out;
+    }
+
+    protected function renderNode(DOMNode $node): string
+    {
+        if ($node instanceof DOMText) {
+            return $this->escape($node->wholeText);
+        }
+
+        if (!$node instanceof DOMElement) {
+            return $this->renderChildren($node);
+        }
+
+        $name = strtolower($node->nodeName);
+
+        return match ($name) {
+            'b', 'strong' => '<b>' . $this->renderChildren($node) . '</b>',
+            'i', 'em' => '<i>' . $this->renderChildren($node) . '</i>',
+            'u' => '<u>' . $this->renderChildren($node) . '</u>',
+            's', 'del', 'strike' => '<s>' . $this->renderChildren($node) . '</s>',
+            'code' => '<code>' . $this->renderChildren($node) . '</code>',
+            'pre' => '<pre>' . $this->renderChildren($node) . '</pre>',
+            'blockquote' => '<blockquote>' . trim($this->renderChildren($node)) . '</blockquote>',
+            'a' => $this->renderLink($node),
+            'br' => "\n",
+            'p', 'div' => $this->renderBlock($node),
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6' => '<b>' . trim($this->renderChildren($node)) . "</b>\n\n",
+            'ul' => $this->renderList($node, true),
+            'ol' => $this->renderList($node, false),
+            'li' => $this->renderChildren($node),
+            default => $this->renderChildren($node),
+        };
+    }
+
+    protected function renderBlock(DOMElement $node): string
+    {
+        $inner = $this->renderChildren($node);
+        $trimmed = trim($inner);
+
+        if ($trimmed === '') {
+            return "\n";
+        }
+
+        return $trimmed . "\n\n";
+    }
+
+    protected function renderLink(DOMElement $node): string
+    {
+        $inner = $this->renderChildren($node);
+        $href = $node->getAttribute('href');
+
+        if ($href === '') {
+            return $inner;
+        }
+
+        $href = htmlspecialchars($href, ENT_QUOTES, 'UTF-8');
+
+        return '<a href="' . $href . '">' . $inner . '</a>';
+    }
+
+    protected function renderList(DOMElement $node, bool $unordered): string
+    {
+        $items = [];
+        $index = 1;
+
+        foreach ($node->childNodes as $child) {
+            if ($child instanceof DOMElement && strtolower($child->nodeName) === 'li') {
+                $inner = trim($this->renderChildren($child));
+                $prefix = $unordered ? '•' : ($index++ . '.');
+                $items[] = $prefix . ' ' . $inner;
+            }
+        }
+
+        if (empty($items)) {
+            return '';
+        }
+
+        return implode("\n", $items) . "\n\n";
+    }
+
+    protected function escape(string $text): string
+    {
+        return htmlspecialchars($text, ENT_NOQUOTES | ENT_HTML5, 'UTF-8');
+    }
+}

--- a/app/Services/TelegramService.php
+++ b/app/Services/TelegramService.php
@@ -3,15 +3,39 @@
 namespace App\Services;
 
 use App\Models\Member;
+use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\Laravel\Facades\Telegram;
 
 class TelegramService
 {
-    public function sendMessage($telegramId, string $message)
+    public function sendMessage($telegramId, string $message, ?string $parseMode = null)
     {
-        return Telegram::sendMessage([
+        $params = [
             'chat_id' => $telegramId,
-            'text' => $message
-        ]);
+            'text' => $message,
+        ];
+
+        if ($parseMode) {
+            $params['parse_mode'] = $parseMode;
+        }
+
+        return Telegram::sendMessage($params);
+    }
+
+    public function sendPhoto($telegramId, string $photoPath, ?string $caption = null, ?string $parseMode = null)
+    {
+        $params = [
+            'chat_id' => $telegramId,
+            'photo' => InputFile::create($photoPath, basename($photoPath)),
+        ];
+
+        if (!is_null($caption) && $caption !== '') {
+            $params['caption'] = $caption;
+            if ($parseMode) {
+                $params['parse_mode'] = $parseMode;
+            }
+        }
+
+        return Telegram::sendPhoto($params);
     }
 }

--- a/app/Settings/TelegramSettings.php
+++ b/app/Settings/TelegramSettings.php
@@ -22,6 +22,7 @@ class TelegramSettings extends Settings
     public bool $show_sales_group = false;
     public bool $show_money_group = false;
     public bool $show_stock_group = true;
+    public bool $show_broadcasts_group = true;
 
     public static function group(): string
     {

--- a/database/migrations/2026_05_15_120000_create_broadcasts_table.php
+++ b/database/migrations/2026_05_15_120000_create_broadcasts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('broadcasts', function (Blueprint $table) {
+            $table->id();
+            $table->text('message');
+            $table->string('audience')->default('all');
+            $table->string('status')->default('pending');
+            $table->unsignedInteger('total_recipients')->default(0);
+            $table->unsignedInteger('sent_count')->default(0);
+            $table->unsignedInteger('failed_count')->default(0);
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('broadcasts');
+    }
+};

--- a/database/migrations/2026_05_15_120100_create_broadcast_recipients_table.php
+++ b/database/migrations/2026_05_15_120100_create_broadcast_recipients_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('broadcast_recipients', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('broadcast_id')->constrained('broadcasts')->cascadeOnDelete();
+            $table->foreignId('member_id')->constrained('members')->cascadeOnDelete();
+            $table->string('telegram_id')->nullable();
+            $table->string('status')->default('pending');
+            $table->text('error_message')->nullable();
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['broadcast_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('broadcast_recipients');
+    }
+};

--- a/database/migrations/2026_05_15_120200_add_is_broadcast_excluded_to_members_table.php
+++ b/database/migrations/2026_05_15_120200_add_is_broadcast_excluded_to_members_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->boolean('is_broadcast_excluded')->default(false)->after('is_subscribed');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('members', function (Blueprint $table) {
+            $table->dropColumn('is_broadcast_excluded');
+        });
+    }
+};

--- a/database/migrations/2026_05_15_130000_add_image_and_parse_mode_to_broadcasts_table.php
+++ b/database/migrations/2026_05_15_130000_add_image_and_parse_mode_to_broadcasts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('broadcasts', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('message');
+            $table->string('parse_mode', 32)->nullable()->after('image_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('broadcasts', function (Blueprint $table) {
+            $table->dropColumn(['image_path', 'parse_mode']);
+        });
+    }
+};

--- a/database/migrations/2026_05_15_140000_drop_is_broadcast_excluded_from_members_table.php
+++ b/database/migrations/2026_05_15_140000_drop_is_broadcast_excluded_from_members_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('members', 'is_broadcast_excluded')) {
+            Schema::table('members', function (Blueprint $table) {
+                $table->dropColumn('is_broadcast_excluded');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasColumn('members', 'is_broadcast_excluded')) {
+            Schema::table('members', function (Blueprint $table) {
+                $table->boolean('is_broadcast_excluded')->default(false)->after('is_subscribed');
+            });
+        }
+    }
+};

--- a/database/settings/2026_05_15_show_broadcasts_group.php
+++ b/database/settings/2026_05_15_show_broadcasts_group.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('telegram.show_broadcasts_group', true);
+    }
+};

--- a/resources/views/filament/broadcasts/progress.blade.php
+++ b/resources/views/filament/broadcasts/progress.blade.php
@@ -1,0 +1,23 @@
+@php
+    /** @var \App\Models\Broadcast $record */
+    $record = $getRecord();
+    $percent = $record->progress_percent;
+    $processed = $record->sent_count + $record->failed_count;
+    $color = match ($record->status) {
+        \App\Models\Broadcast::STATUS_COMPLETED => 'bg-success-500',
+        \App\Models\Broadcast::STATUS_CANCELLED => 'bg-danger-500',
+        \App\Models\Broadcast::STATUS_IN_PROGRESS => 'bg-warning-500',
+        default => 'bg-gray-400',
+    };
+@endphp
+
+<div class="w-full">
+    <div class="flex justify-between text-xs mb-1 text-gray-600 dark:text-gray-300">
+        <span>{{ $processed }} / {{ $record->total_recipients }}</span>
+        <span>{{ $percent }}%</span>
+    </div>
+    <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
+        <div class="{{ $color }} h-3 rounded-full transition-all duration-500"
+             style="width: {{ $percent }}%"></div>
+    </div>
+</div>


### PR DESCRIPTION
- BroadcastResource (List/Create/View, без Edit) у групі "Розсилка"
- RichEditor (Trix) для тіла повідомлення з підтримкою B/I/U/S, посилань, цитат, списків — без HTML/Markdown руками
- TelegramHtmlConverter: Trix-HTML → Telegram-сумісний HTML (parse_mode=HTML)
- Завантаження зображення (sendPhoto з caption або окремо при тексті > 1024)
- Аудиторія: всі / з підпискою / без підписки; одноразове виключення конкретних користувачів через searchable Select на формі
- SendBroadcastMessageJob: відправка по черзі з рандомним інтервалом 30-60 сек через чергу database, статуси одержувачів (pending/sent/failed/skipped)
- Прогресбар і авто-оновлення (poll) у списку, на сторінці деталей і у списку одержувачів; кнопка скасування розсилки
- Налаштування show_broadcasts_group у TelegramSettings